### PR TITLE
Keep track of the (in)finiteness of types

### DIFF
--- a/examples/recursive/lst.ml
+++ b/examples/recursive/lst.ml
@@ -1,3 +1,5 @@
 type pos = (int[@satisfying fun x -> x >= 0])
 
 type pos_list = Empty | Cons of pos * pos_list
+
+type pair = pos_list * float

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -174,7 +174,7 @@ let md str = String.split_on_char '*' str |> String.concat "\\*"
 
 (* pretty printing of large numbers: if cardinality is big, we print it as a
    power of 2 for readability *)
-let print_card =
+let print_bigint =
   let z15 = Z.of_int 32768 in
   let close_log z =
     let down = Z.log2 z in

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -27,7 +27,7 @@ module Card = struct
   let pp fmt = function
     | Unknown -> Format.pp_print_string fmt "unknown"
     | Infinite -> Format.pp_print_string fmt "infinite"
-    | Finite n -> Z.pp_print fmt n
+    | Finite n -> Helper.print_bigint fmt n
 end
 
 type t =


### PR DESCRIPTION
This patch:

- drops the arguably confusing `is_rec` flag in Typerepr.t which used to mean "infinite"
- adds a new data type for cardinality:
```ocaml
type t =
  | Unknown
  | Infinite
  | Finite of Z.t
```
- implements the `cardinality` function for sums, products and records

---

**NB**: we might still need the `is_rec` flag to handle situations like:

```ocaml
type t = int
type nonrec t = A of t | B
```
versus
```ocaml
type t = A of t | B
```

But I think this is better left to another PR