### PR TITLE
Compile a rewriter executable for testing purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,14 @@
-BIN=rewrite
-
 all:
 	@dune build
+	@dune build src/rewriter.exe
 
 test:
 	@dune runtest --force -j1 --no-buffer
 
 clean:
-	@rm -f $(BIN)
 	@rm -f *.log
 	@dune clean
 	@rm -f *.markdown
 	@rm -rf testdir_*
 
-.PHONY: build test clean $(BIN)
+.PHONY: build test clean

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
-if [[ $# -eq 0 ]] ; then
+set -euC
+
+if [ $# -eq 0 ]; then
     echo 'Error: was expecting some OCaml file'
-    exit 0
+    exit 1
 fi
 fbname=$(basename "$1" .ml)
 dir="testdir_$fbname"
-mkdir -p $dir
-cp -f ./_build/default/.ppx/*/ppx.exe rewrite
-./rewrite $1 -log > $dir/a.ml
-[ ! -f log.svg ] || mv log.svg $dir/
-rm -f rewrite
-mv log.markdown $dir
-echo "(executable (name a)(libraries testify_runtime)) " > $dir/dune
-dune build $dir
+mkdir -p "$dir"
+dune exec src/rewriter.exe -- "$1" -log > "$dir/a.ml"
+[ ! -f log.svg ] || mv log.svg "$dir"/
+mv log.markdown "$dir"
+echo "(executable (name a)(libraries testify_runtime)) " > "$dir/dune"
+dune build "$dir"

--- a/src/dune
+++ b/src/dune
@@ -15,4 +15,9 @@
      ocaml-migrate-parsetree
      apron apron.boxMPQ apron.polkaMPQ apronext
      picasso)
-)             
+  (modules :standard \ Rewriter))
+
+(executable
+  (name rewriter)
+  (modules Rewriter)
+  (libraries ppx_testify ppxlib))

--- a/src/rewriter.ml
+++ b/src/rewriter.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()


### PR DESCRIPTION
`cp -f ./_build/default/.ppx/*/ppx.exe rewrite` feels hackish and fails if more than one ppx is used (eg. when I add metaquot to the mix).

We compile a rewriter executable explicitely rather than relying on the above hack (source: https://tarides.com/blog/2019-05-09-an-introduction-to-ocaml-ppx-ecosystem#testing-your-ppx)