### PR TITLE
Add support for mutually recursive typs

### DIFF
--- a/examples/recursive/mutual.ml
+++ b/examples/recursive/mutual.ml
@@ -1,3 +1,3 @@
-type t' = Int of int | Add of t * t
+type desc = Int of int | Add of t * t
 
-and t = {annotation: string; data: t'}
+and t = {annotation: int; desc: desc}

--- a/examples/recursive/mutual.ml
+++ b/examples/recursive/mutual.ml
@@ -1,3 +1,8 @@
-type desc = Int of int | Add of t * t
+type pos = (int[@satisfying fun x -> 0 <= x])
+
+type desc = Int of pos | Add of t * t
 
 and t = {annotation: int; desc: desc}
+
+let rec eval (x : t) : pos =
+  match x.desc with Int n -> n | Add (x, y) -> eval x + eval y

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -1,4 +1,4 @@
-(* This module provides helpers for ast building *)
+(* This module provides helpers for ast building (and other stuff) *)
 
 (* keep this before open as module Parse is shadowed by open
    Migrate_parsetree *)
@@ -307,3 +307,18 @@ let rec_nonrec recflag typs =
   let rec_ = recursive recflag typs in
   let nonrec_ = List.filter (fun t -> not (List.mem t rec_)) typs in
   (rec_, nonrec_)
+
+(** {2 Add some functions to the stdlib} *)
+
+module List = struct
+  include List
+
+  (** Yeah I know... *)
+  let rec map4 f l1 l2 l3 l4 =
+    match (l1, l2, l3, l4) with
+    | [], [], [], [] -> []
+    | x1 :: l1, x2 :: l2, x3 :: l3, x4 :: l4 ->
+        let y = f x1 x2 x3 x4 in
+        y :: map4 f l1 l2 l3 l4
+    | _ -> invalid_arg "List.map4"
+end

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -153,7 +153,7 @@ let derive state (recflag, typs) =
           (fun acc td ->
             Module_state.update acc
               (lparse td.ptype_name.txt)
-              (Typrepr.make_rec td.ptype_name.txt) )
+              (Typrepr.Rec.make td.ptype_name.txt) )
           state typs
     | Nonrecursive -> state
   in
@@ -185,7 +185,7 @@ let derive state (recflag, typs) =
         | [] ->
             let typrepr =
               Module_state.get id acc |> Option.get
-              |> Typrepr.finish_rec td.ptype_name.txt
+              |> Typrepr.Rec.finish td.ptype_name.txt
             in
             Log.print "%a\n%!" Typrepr.print typrepr ;
             Module_state.update acc id typrepr

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -346,7 +346,8 @@ module Sum = struct
                  let card = Product.cardinality typs |> Card.as_z in
                  Helper.pair (weight card)
                    (constr_generator constr typs |> Option.get) )
-               variants ) ]
+               variants )
+        ; exp_id "rs" ]
       |> lambda_s "rs" |> Option.some
     with Exit | Invalid_argument _ -> None
 


### PR DESCRIPTION
Sorry, pretty big diff…

This patch
- fixes a bug in cycle detection
- encapsulate the recursive machinery in `Typrepr.Rec`
- generates mutally recursive functions for mutually recursive types