### PR TITLE
Draft: Kerl/boltzmann

### DIFF
--- a/examples/recursive/abr.ml
+++ b/examples/recursive/abr.ml
@@ -8,3 +8,10 @@ let rec insert (x : int) (bt : binary_tree) : binary_tree =
   | Leaf -> Node (Leaf, x, Leaf)
   | Node (l, x', r) ->
       if x < x' then Node (insert x l, x', r) else Node (l, x', insert x r)
+
+let rec insert_buggy (x : int) (bt : binary_tree) : binary_tree =
+  match bt with
+  | Leaf -> Node (Leaf, x, Leaf)
+  | Node (l, x', r) ->
+      if x < x' then Node (insert_buggy x' l, x, r)
+      else Node (l, x', insert_buggy x r)

--- a/examples/recursive/abr.ml
+++ b/examples/recursive/abr.ml
@@ -1,4 +1,10 @@
 type binary_tree =
   | Node of binary_tree * (int[@collect]) * binary_tree
   | Leaf
-[@@satisfying fun x -> increasing x]
+[@@satisfying increasing]
+
+let rec insert (x : int) (bt : binary_tree) : binary_tree =
+  match bt with
+  | Leaf -> Node (Leaf, x, Leaf)
+  | Node (l, x', r) ->
+      if x < x' then Node (insert x l, x', r) else Node (l, x', insert x r)

--- a/examples/recursive/lst.ml
+++ b/examples/recursive/lst.ml
@@ -1,16 +1,8 @@
-type pos = (int[@satisfying fun x -> x >= 0])
-
-type 'a lst = 'a list = [] | ( :: ) of 'a * 'a list
-
-(* let length (l : int lst) : pos = List.length l *)
-
-type pos_list = Empty | Cons of pos * pos_list
-
-type pair = pos_list * float
-
-(* let mean (pl : pos_list) : pos =
+(* type pos = (int[@satisfying fun x -> x >= 0])
+ *
+ * let mean (pl : pos list) : pos option =
  *   let rec loop (sum, nb) = function
- *     | Empty -> sum / nb
- *     | Cons (h, tl) -> loop (sum + h, nb + 1) tl
+ *     | [] -> sum / nb
+ *     | h :: tl -> loop (sum + h, nb + 1) tl
  *   in
- *   loop (0, 0) pl *)
+ *   match pl with [] -> None | h :: tl -> Some (loop (h, 1) tl) *)

--- a/examples/recursive/map.ml
+++ b/examples/recursive/map.ml
@@ -2,7 +2,4 @@ type map =
   | Node of map * (int[@collect]) * int * map
   (* left * key * value * right *)
   | Leaf
-[@@satisfying
-  fun x ->
-    let l = depth_first_search x in
-    increasing l && all_diff l]
+[@@satisfying increasing]

--- a/examples/recursive/mutual.ml
+++ b/examples/recursive/mutual.ml
@@ -1,8 +1,3 @@
-type pos = (int[@satisfying fun x -> 0 <= x])
+type tree = Leaf | Node of node
 
-type desc = Int of pos | Add of t * t
-
-and t = {annotation: int; desc: desc}
-
-let rec eval (x : t) : pos =
-  match x.desc with Int n -> n | Add (x, y) -> eval x + eval y
+and node = int * tree * tree

--- a/examples/recursive/nat.ml
+++ b/examples/recursive/nat.ml
@@ -1,0 +1,21 @@
+(** Tests the support for infinite types that are not recursive. *)
+
+(* This is recursive *)
+type nat = Zero | Succ of nat
+
+let rec le n m =
+  match (n, m) with
+  | Zero, _ -> true
+  | _, Zero -> false
+  | Succ n, Succ m -> le n m
+
+(* This is not *)
+type interval = nat * nat [@@satisfying fun (x, y) -> le x y]
+
+let incr (itv : interval) : interval =
+  let n, m = itv in
+  (Succ n, Succ m)
+
+let incr_buggy (itv : interval) : interval =
+  let n, m = itv in
+  (Succ n, m)

--- a/examples/testifytests/constr.ml
+++ b/examples/testifytests/constr.ml
@@ -1,3 +1,5 @@
+(* this test hightlights the use of intersection types *)
+
 type nat = (int[@satisfying fun x -> x > 0])
 
 let rec log2 (x : nat) : (nat[@satisfying fun x -> x < 62]) =

--- a/runtime/dune
+++ b/runtime/dune
@@ -1,4 +1,4 @@
 (library
   (public_name testify_runtime)
   (name testify_runtime)
-  (libraries qcheck))
+  (libraries qcheck arbogen))

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -99,25 +99,25 @@ let weighted (gens : (float * 'a QCheck.Gen.t) list) : 'a QCheck.Gen.t =
 module Arbg = struct
   open Arbogen.Tree
 
-  let arbogen_to_unit arbg lst rs =
+  let to_unit arbg lst rs =
     match arbg with
     | Node ("@collect", []) -> consume lst
     | Node (_, []) -> (QCheck.Gen.unit rs, lst)
     | Node (_, _) -> invalid_arg "arbogen_to_unit"
 
-  let arbogen_to_bool arbg lst rs =
+  let to_bool arbg lst rs =
     match arbg with
     | Node ("@collect", []) -> consume lst
     | Node (_, []) -> (QCheck.Gen.bool rs, lst)
     | Node (_, _) -> invalid_arg "arbogen_to_bool"
 
-  let arbogen_to_int arbg lst rs =
+  let to_int arbg lst rs =
     match arbg with
     | Node ("@collect", []) -> consume lst
     | Node (_, []) -> (QCheck.Gen.int rs, lst)
     | Node (_, _) -> invalid_arg "arbogen_to_int"
 
-  let arbogen_to_float arbg lst rs =
+  let to_float arbg lst rs =
     match arbg with
     | Node ("@collect", []) -> consume lst
     | Node (_, []) -> (QCheck.Gen.float rs, lst)

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -97,7 +97,12 @@ let weighted (gens : (float * 'a QCheck.Gen.t) list) : 'a QCheck.Gen.t =
     (aux r gens) rs
 
 module Arbg = struct
-  open Arbogen.Tree
+  open Arbogen
+  open Tree
+
+  let max_try = ref 1_000_000
+
+  let size = ref 30
 
   let to_unit arbg lst rs =
     match arbg with
@@ -126,6 +131,21 @@ module Arbg = struct
   let count_collect =
     fold (fun lab ->
         List.fold_left ( + ) (if String.equal lab "@collect" then 1 else 0) )
+
+  let search_seed grammar =
+    let s =
+      Boltzmann.search_seed
+        (module Randtools.OcamlRandom)
+        grammar
+        ~size_min:(int_of_float (0.9 *. float !size))
+        ~size_max:!size
+    in
+    match s with
+    | Some (_size, state) -> state
+    | None -> failwith "could not find seed"
+
+  let free_gen grammar name =
+    fst @@ Boltzmann.free_gen (module Randtools.OcamlRandom) grammar name
 end
 
 let count = ref 1000

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -132,19 +132,22 @@ module Arbg = struct
     fold (fun lab ->
         List.fold_left ( + ) (if String.equal lab "@collect" then 1 else 0) )
 
-  let search_seed grammar =
-    let s =
-      Boltzmann.search_seed
-        (module Randtools.OcamlRandom)
-        grammar
-        ~size_min:(int_of_float (0.9 *. float !size))
-        ~size_max:!size
+  let free_gen grammar name rs =
+    let search_seed grammar =
+      let s =
+        Boltzmann.search_seed
+          (module Randtools.OcamlRandom)
+          grammar
+          ~size_min:(int_of_float (0.9 *. float !size))
+          ~size_max:!size
+      in
+      match s with
+      | Some (_size, state) -> state
+      | None -> failwith "could not find seed"
     in
-    match s with
-    | Some (_size, state) -> state
-    | None -> failwith "could not find seed"
-
-  let free_gen grammar name =
+    Random.set_state rs ;
+    let state = search_seed grammar in
+    Randtools.OcamlRandom.set_state state ;
     fst @@ Boltzmann.free_gen (module Randtools.OcamlRandom) grammar name
 end
 

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -153,15 +153,15 @@ end
 
 (* collectors *)
 module Collect = struct
-  let unit l () = () :: l
+  let unit () = [()]
 
-  let bool l (x : bool) = x :: l
+  let bool (x : bool) = [x]
 
-  let char l (x : char) = x :: l
+  let char (x : char) = [x]
 
-  let int l (x : int) = x :: l
+  let int (x : int) = [x]
 
-  let float l (x : float) = x :: l
+  let float (x : float) = [x]
 end
 
 let count = ref 1000

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -1,12 +1,20 @@
 let tests = ref ([] : QCheck.Test.t list)
 
+(* same as [pp], but in bold blue] *)
+let bold_blue x = Format.asprintf "\x1b[34;1m%s\x1b[0m" x
+
+(* same as [pp], but in blue *)
+let blue x = Format.asprintf "\x1b[36m%s\x1b[0m" x
+
 (* test storing management *)
-let add_fun count name print gen pred =
+let add_fun count id loc print gen pred =
+  let name = Format.asprintf "function %s in %s" (bold_blue id) (blue loc) in
   let arb = QCheck.make ~print gen in
   let t = QCheck.Test.make ~count ~name arb pred in
   tests := t :: !tests
 
-let add_const count name pred =
+let add_const count id loc pred =
+  let name = Format.asprintf "constant %s in %s" (bold_blue id) (blue loc) in
   let arb = QCheck.make QCheck.Gen.unit in
   let t = QCheck.Test.make ~count ~name arb pred in
   tests := t :: !tests

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -151,6 +151,19 @@ module Arbg = struct
     fst @@ Boltzmann.free_gen (module Randtools.OcamlRandom) grammar name
 end
 
+(* collectors *)
+module Collect = struct
+  let unit l () = () :: l
+
+  let bool l (x : bool) = x :: l
+
+  let char l (x : char) = x :: l
+
+  let int l (x : int) = x :: l
+
+  let float l (x : float) = x :: l
+end
+
 let count = ref 1000
 
 let reject pred g = QCheck.find_example ~f:pred ~count:!count g
@@ -194,6 +207,24 @@ let simplex seed (x : instance) (vectors : instance list) (nb_dim : int) =
       List.rev_map (fun f -> 1. -. f) random_vecs
     else List.rev random_vecs )
     vectors
+
+let is_increasing l =
+  match l with
+  | h :: t -> (
+    try
+      List.fold_left (fun acc e -> if acc <= e then e else raise Exit) h t ;
+      true
+    with Exit -> false )
+  | [] -> true
+
+let is_increasing_s l =
+  match l with
+  | h :: t -> (
+    try
+      List.fold_left (fun acc e -> if acc < e then e else raise Exit) h t ;
+      true
+    with Exit -> false )
+  | [] -> true
 
 let memo f =
   let tbl = Hashtbl.create 1000 in

--- a/runtime/testify_runtime.ml
+++ b/runtime/testify_runtime.ml
@@ -217,7 +217,8 @@ let is_increasing l =
   match l with
   | h :: t -> (
     try
-      List.fold_left (fun acc e -> if acc <= e then e else raise Exit) h t ;
+      List.fold_left (fun acc e -> if acc <= e then e else raise Exit) h t
+      |> ignore ;
       true
     with Exit -> false )
   | [] -> true
@@ -226,7 +227,8 @@ let is_increasing_s l =
   match l with
   | h :: t -> (
     try
-      List.fold_left (fun acc e -> if acc < e then e else raise Exit) h t ;
+      List.fold_left (fun acc e -> if acc < e then e else raise Exit) h t
+      |> ignore ;
       true
     with Exit -> false )
   | [] -> true

--- a/src/boltz.ml
+++ b/src/boltz.ml
@@ -1,12 +1,11 @@
 open Arbogen
 
-type t = {spec: string Grammar.expression; aux_rules: Frontend.ParseTree.t}
-
-(** {2 Getters} *)
-
-let spec {spec; _} = spec
-
-let aux_rules {aux_rules; _} = aux_rules
+(** Combinatorial description of a type *)
+type t =
+  { spec: string Grammar.expression  (** Main specification of the type *)
+  ; aux_rules: Frontend.ParseTree.t
+        (** Auxilliary rules that can be used by the main specification e.g.
+            for recursive specs *) }
 
 (** {2 Base cases and combinators} *)
 
@@ -17,12 +16,12 @@ let z = {spec= Grammar.Z 1; aux_rules= []}
 let ref name = {spec= Grammar.Ref name; aux_rules= []}
 
 let product args =
-  { spec= List.map spec args |> Grammar.product
-  ; aux_rules= List.map aux_rules args |> List.flatten }
+  { spec= List.map (fun b -> b.spec) args |> Grammar.product
+  ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
 
 let union args =
-  { spec= List.map spec args |> Grammar.union
-  ; aux_rules= List.map aux_rules args |> List.flatten }
+  { spec= List.map (fun b -> b.spec) args |> Grammar.union
+  ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
 
 let indirection name boltz =
   {spec= Grammar.Ref name; aux_rules= (name, boltz.spec) :: boltz.aux_rules}

--- a/src/boltz.ml
+++ b/src/boltz.ml
@@ -15,13 +15,19 @@ let z = {spec= Grammar.Z 1; aux_rules= []}
 
 let ref name = {spec= Grammar.Ref name; aux_rules= []}
 
-let product args =
-  { spec= List.map (fun b -> b.spec) args |> Grammar.product
-  ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
+let product = function
+  | [] -> invalid_arg "Boltz.product: empty product"
+  | [x] -> x
+  | args ->
+      { spec= List.map (fun b -> b.spec) args |> Grammar.product
+      ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
 
-let union args =
-  { spec= List.map (fun b -> b.spec) args |> Grammar.union
-  ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
+let union = function
+  | [] -> invalid_arg "Boltz.union: empty union"
+  | [x] -> x
+  | args ->
+      { spec= List.map (fun b -> b.spec) args |> Grammar.union
+      ; aux_rules= List.map (fun b -> b.aux_rules) args |> List.flatten }
 
 let indirection name boltz =
   {spec= Grammar.Ref name; aux_rules= (name, boltz.spec) :: boltz.aux_rules}

--- a/src/boltz.ml
+++ b/src/boltz.ml
@@ -1,0 +1,44 @@
+open Arbogen
+
+type t = {spec: string Grammar.expression; aux_rules: Frontend.ParseTree.t}
+
+(** {2 Getters} *)
+
+let spec {spec; _} = spec
+
+let aux_rules {aux_rules; _} = aux_rules
+
+(** {2 Base cases and combinators} *)
+
+let epsilon = {spec= Grammar.Z 0; aux_rules= []}
+
+let z = {spec= Grammar.Z 1; aux_rules= []}
+
+let ref name = {spec= Grammar.Ref name; aux_rules= []}
+
+let product args =
+  { spec= List.map spec args |> Grammar.product
+  ; aux_rules= List.map aux_rules args |> List.flatten }
+
+let union args =
+  { spec= List.map spec args |> Grammar.union
+  ; aux_rules= List.map aux_rules args |> List.flatten }
+
+let indirection name boltz =
+  {spec= Grammar.Ref name; aux_rules= (name, boltz.spec) :: boltz.aux_rules}
+
+(** {2 Conversion} *)
+
+let as_grammar name {spec; aux_rules} = (name, spec) :: aux_rules
+
+(** {2 Pretty printing} *)
+
+let pp fmt {spec; aux_rules} =
+  Arbogen.Grammar.pp_expression ~pp_ref:Format.pp_print_string fmt spec ;
+  match aux_rules with
+  | [] -> ()
+  | _ ->
+      Format.fprintf fmt "\nwhere:\n%a" Arbogen.Frontend.ParseTree.pp
+        aux_rules
+
+let markdown fmt = Format.fprintf fmt "```\n%a\n```\n" pp

--- a/src/dune
+++ b/src/dune
@@ -14,8 +14,10 @@
      ppx_tools_versioned
      ocaml-migrate-parsetree
      apron apron.boxMPQ apron.polkaMPQ apronext
-     picasso)
-  (modules :standard \ Rewriter))
+     picasso
+     arbogen)
+  (modules :standard \ Rewriter)
+  (preprocess (pps ppxlib.metaquot)))
 
 (executable
   (name rewriter)

--- a/src/gegen.ml
+++ b/src/gegen.ml
@@ -45,7 +45,12 @@ let collect_ct core_type pattern : SSet.t * SSet.t =
         List.fold_left2
           (fun (i_s, f_s) tt pt -> aux i_s f_s tt pt)
           (int_set, float_set) ttup ptup
-    | _ -> raise (Lang.OutOfSubset "core_type or pattern")
+    | _ ->
+        let msg =
+          Format.asprintf "type %a and pattern %a are incompatible"
+            print_coretype ct print_pat pattern
+        in
+        raise (Lang.OutOfSubset msg)
   in
   aux SSet.empty SSet.empty core_type (fill pattern)
 
@@ -193,8 +198,9 @@ let solve_ct ct sat =
       print_coretype ct ;
     None
 
-let flatten_record labs sat _td =
-  try
+(* generator for constrained type declarations *)
+let solve_td td sat =
+  let flatten_record labs sat _td =
     let pat, body = split_fun sat in
     let constr = Lang.of_ocaml body in
     let i_s, f_s = collect_record labs in
@@ -203,13 +209,10 @@ let flatten_record labs sat _td =
     let inner, outer, total = get_generators i_s f_s constr !max_size in
     let g = craft_generator inner outer total pat unflatten unflatten_ind in
     Some (g, total)
-  with Lang.OutOfSubset _ -> None
-
-let flatten_abstract td sat =
-  Option.bind td.ptype_manifest (fun ct -> solve_ct ct sat)
-
-(* generator for constrained type declarations *)
-let solve_td td sat =
+  in
+  let flatten_abstract td sat =
+    Option.bind td.ptype_manifest (fun ct -> solve_ct ct sat)
+  in
   try
     match td.ptype_kind with
     | Ptype_abstract -> flatten_abstract td sat

--- a/src/gegen.ml
+++ b/src/gegen.ml
@@ -188,7 +188,10 @@ let solve_ct ct sat =
     let inner, outer, total = get_generators i_s f_s constr !max_size in
     let g = craft_generator inner outer total pat unflatten unflatten_ind in
     Some (g, total)
-  with Lang.OutOfSubset _ -> None
+  with e ->
+    Log.warn "solver failure %s on type %a" (Printexc.to_string e)
+      print_coretype ct ;
+    None
 
 let flatten_record labs sat _td =
   try
@@ -207,8 +210,13 @@ let flatten_abstract td sat =
 
 (* generator for constrained type declarations *)
 let solve_td td sat =
-  match td.ptype_kind with
-  | Ptype_abstract -> flatten_abstract td sat
-  | Ptype_record labs -> flatten_record labs sat td
-  | Ptype_variant _ -> None
-  | Ptype_open -> None
+  try
+    match td.ptype_kind with
+    | Ptype_abstract -> flatten_abstract td sat
+    | Ptype_record labs -> flatten_record labs sat td
+    | Ptype_variant _ -> None
+    | Ptype_open -> None
+  with e ->
+    Log.warn "solver failure %s on type@.%a" (Printexc.to_string e)
+      print_type_decl td ;
+    None

--- a/src/globalConstraint.ml
+++ b/src/globalConstraint.ml
@@ -42,10 +42,11 @@ let all =
   ; make_not_implemented "increasing_strict"
   ; make_not_implemented "decreasing_strict" ]
 
-(* accepts global constraints of the form:
-   - [@satisfying ID]
-   - [@satisfying fun x -> ID x]
-   where ID belongs to the list of predefined constraints `all` *)
+(** Accepts global constraints of the form:
+
+    - [@satisfying ID]
+    - [@satisfying fun x -> ID x] where ID belongs to the list of predefined
+      constraints `all` *)
 let search (c : expression) : t option =
   match c.pexp_desc with
   | Pexp_ident id ->

--- a/src/globalConstraint.ml
+++ b/src/globalConstraint.ml
@@ -1,0 +1,54 @@
+(** {1 Global constraint} *)
+
+open Migrate_parsetree.Ast_410
+open Parsetree
+
+type t =
+  { id: string  (** The name of the corresponding OCaml attribute *)
+  ; value_provider:
+      Location.t -> Migrate_parsetree.Ast_410.Parsetree.expression
+        (** Ast for the value provider used during Boltzmann generation.
+            Takes a location as an input for better error handling. *) }
+
+(** {2 Pre-defined constraints} *)
+
+let increasing =
+  { id= "increasing"
+  ; value_provider=
+      (fun loc ->
+        [%expr
+          fun nb_collect ->
+            List.init nb_collect (fun _ -> Random.bits ())
+            |> List.sort Int.compare] ) }
+
+let make_not_implemented id =
+  { id
+  ; value_provider=
+      (fun _loc ->
+        Format.ksprintf failwith "Not implemented: global constraint \"%s\""
+          id ) }
+
+let all =
+  [ make_not_implemented "alldiff"
+  ; increasing
+  ; make_not_implemented "decreasing"
+  ; make_not_implemented "increasing_strict"
+  ; make_not_implemented "decreasing_strict" ]
+
+let search (c : expression) : t option =
+  match c.pexp_desc with
+  | Pexp_ident id ->
+      let id = Helper.lid_to_string id.txt in
+      List.find_opt (fun gc -> gc.id = id) all
+  | Pexp_fun (Nolabel, None, pat, body) -> (
+    match (pat.ppat_desc, body.pexp_desc) with
+    | ( Ppat_var arg
+      , Pexp_apply
+          ( {pexp_desc= Pexp_ident funname; _}
+          , [(Nolabel, {pexp_desc= Pexp_ident arg'; _})] ) ) ->
+        let funname = Helper.lid_to_string funname.txt in
+        if arg.txt = Helper.lid_to_string arg'.txt then
+          List.find_opt (fun gc -> gc.id = funname) all
+        else None
+    | _ -> None )
+  | _ -> None

--- a/src/globalConstraint.ml
+++ b/src/globalConstraint.ml
@@ -42,7 +42,7 @@ let all =
   ; make_not_implemented "increasing_strict"
   ; make_not_implemented "decreasing_strict" ]
 
-(* accpets global constraints of the form:
+(* accepts global constraints of the form:
    - [@satisfying ID]
    - [@satisfying fun x -> ID x]
    where ID belongs to the list of predefined constraints `all` *)

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -219,15 +219,6 @@ let has_attribute n attrs = get_attribute_payload n attrs |> Option.is_some
 
 (* printing *)
 
-(* same as [pp], but in bold blue] *)
-let bold_blue x = Format.asprintf "\x1b[34;1m%s\x1b[0m" x
-
-(* same as [pp], but in blue *)
-let blue x = Format.asprintf "\x1b[36m%s\x1b[0m" x
-
-(* same as [pp], but in gray *)
-let gray x = Format.asprintf "\x1b[37m%s\x1b[0m" x
-
 module Conv = Convert (OCaml_410) (OCaml_current)
 
 let print_expression fmt e =

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -37,6 +37,8 @@ module Pat = struct
 
   let tuple = Pat.tuple ~loc:!current_loc
 
+  let pair a b = tuple [a; b]
+
   let construct_s str = Pat.construct ~loc:!current_loc (lid_loc str)
 
   let record list = Pat.record ~loc:!current_loc list
@@ -71,6 +73,8 @@ let capitalize_first_char str =
 
 (* calls a function defined in the runtime *)
 let apply_runtime s = apply_nolbl_s ("Testify_runtime." ^ s)
+
+let assert_ = Exp.assert_ ~loc:!current_loc
 
 (* Same as Exp.fun_ *)
 let lambda = Exp.fun_ ~loc:!current_loc Nolabel None

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -239,6 +239,12 @@ let print_td fmt (recflag, types) =
   in
   Pprintast.signature fmt (Conv.copy_signature [sig_])
 
+let print_type_decl fmt t =
+  let sig_ =
+    {psig_desc= Psig_type (Recursive, [t]); psig_loc= Location.none}
+  in
+  Pprintast.signature fmt (Conv.copy_signature [sig_])
+
 (* markdown escaping *)
 let md str = String.split_on_char '*' str |> String.concat "\\*"
 

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -312,10 +312,10 @@ let rec trim exp =
     | _ -> exp )
   | _ -> exp
 
-(* (\* we overload applies function to simplify them by default *\)
- * let apply_nolbl_s name args = apply_nolbl_s name args |> trim
- *
- * let apply_nolbl func args = apply_nolbl func args |> trim *)
+(* we overload applies function to simplify them by default *)
+let apply_nolbl_s name args = apply_nolbl_s name args |> trim
+
+let apply_nolbl func args = apply_nolbl func args |> trim
 
 (* recursive type detection *)
 (****************************)

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -74,10 +74,6 @@ let capitalize_first_char str =
 (* calls a function defined in the runtime *)
 let apply_runtime s = apply_nolbl_s ("Testify_runtime." ^ s)
 
-let assert_ = Exp.assert_ ~loc:!current_loc
-
-let failwith_ str = apply_nolbl_s "failwith" [str]
-
 (* Same as Exp.fun_ *)
 let lambda = Exp.fun_ ~loc:!current_loc Nolabel None
 

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -312,10 +312,10 @@ let rec trim exp =
     | _ -> exp )
   | _ -> exp
 
-(* we overload applies function to simplify them by default *)
-let apply_nolbl_s name args = apply_nolbl_s name args |> trim
-
-let apply_nolbl func args = apply_nolbl func args |> trim
+(* (\* we overload applies function to simplify them by default *\)
+ * let apply_nolbl_s name args = apply_nolbl_s name args |> trim
+ *
+ * let apply_nolbl func args = apply_nolbl func args |> trim *)
 
 (* recursive type detection *)
 (****************************)

--- a/src/helper.ml
+++ b/src/helper.ml
@@ -76,6 +76,8 @@ let apply_runtime s = apply_nolbl_s ("Testify_runtime." ^ s)
 
 let assert_ = Exp.assert_ ~loc:!current_loc
 
+let failwith_ str = apply_nolbl_s "failwith" [str]
+
 (* Same as Exp.fun_ *)
 let lambda = Exp.fun_ ~loc:!current_loc Nolabel None
 
@@ -411,12 +413,12 @@ module List = struct
   include List
 
   (** Yeah I know... *)
-  let rec map5 f l1 l2 l3 l4 l5 =
-    match (l1, l2, l3, l4, l5) with
-    | [], [], [], [], [] -> []
-    | x1 :: l1, x2 :: l2, x3 :: l3, x4 :: l4, x5 :: l5 ->
-        let y = f x1 x2 x3 x4 x5 in
-        y :: map5 f l1 l2 l3 l4 l5
+  let rec map6 f l1 l2 l3 l4 l5 l6 =
+    match (l1, l2, l3, l4, l5, l6) with
+    | [], [], [], [], [], [] -> []
+    | x1 :: l1, x2 :: l2, x3 :: l3, x4 :: l4, x5 :: l5, x6 :: l6 ->
+        let y = f x1 x2 x3 x4 x5 x6 in
+        y :: map6 f l1 l2 l3 l4 l5 l6
     | _ -> invalid_arg "List.map4"
 end
 

--- a/src/log.ml
+++ b/src/log.ml
@@ -1,4 +1,15 @@
-(* log file generation *)
+(** Logging *)
+
+(** {2 Warnings and errors} *)
+
+let _alert prefix = Format.kasprintf (Format.eprintf "%s: %s@." prefix)
+
+let error args = _alert "ERROR" args
+
+let warn args = _alert "WARNING" args
+
+(** {2 Log file generation} *)
+
 let log = ref false
 
 let format : Format.formatter option ref = ref None

--- a/src/module_state.ml
+++ b/src/module_state.ml
@@ -44,6 +44,16 @@ let get_param lid s =
   in
   find lid s
 
+let join (e1 : Typrepr.param State.Env.t) (e2 : Typrepr.param State.Env.t) =
+  State.(Env.fold Env.add e1 e2)
+
+let get_all_params (s : t) =
+  List.fold_left
+    (fun acc (_, m) -> join m.State.params acc)
+    State.Env.empty s
+  |> State.Env.bindings |> List.map snd
+  |> List.map (fun p -> p.Typrepr.body)
+
 let update (s : t) id infos =
   match s with
   | (name, h) :: tl -> (name, State.update h id infos) :: tl

--- a/src/ppx_testify.ml
+++ b/src/ppx_testify.ml
@@ -1,8 +1,9 @@
 let args =
-  let open Satisfying in
-  [ ("-nb", Arg.Int (( := ) number), "Sets the number of runs per test")
+  [ ( "-nb"
+    , Arg.Int (( := ) Satisfying.number)
+    , "Sets the number of runs per test" )
   ; ("-log", Arg.Unit Log.set_output, "Enables the generation of a report")
-  ; ("-seed", Arg.Int gen_set_seed, "Sets the random seed")
+  ; ("-seed", Arg.Int Satisfying.set_seed, "Sets the random seed")
   ; ( "-cover_size"
     , Arg.Int Gegen.set_size
     , "Sets the maximum size of a cover seed" )

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -202,9 +202,7 @@ let derive state (recflag, typs) =
             let name = td.ptype_name.txt in
             let typ =
               match Module_state.get (lparse name) state with
-              | Some typ ->
-                  assert (Option.is_some typ.gen) ;
-                  typ
+              | Some typ -> typ
               | None -> exit 1
             in
             ((name, typ) :: mono, poly)

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -165,7 +165,10 @@ and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
   | None -> (
     match ct.ptyp_desc with
     | Ptyp_var var -> List.assoc var params
-    | Ptyp_constr ({txt; _}, []) -> Module_state.get txt state |> Option.get
+    | Ptyp_constr ({txt; _}, []) ->
+        Option.fold ~some:Fun.id
+          ~none:(Typrepr.empty (lid_to_string txt))
+          (Module_state.get txt state)
     | Ptyp_constr ({txt; _}, l) ->
         let p = Module_state.get_param txt state |> Option.get in
         let env = State.get_env p (List.map (derive_ctype state params) l) in

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -135,8 +135,9 @@ let rec derive_decl (s : Module_state.t) params
     | None -> (
       match ptype_kind with
       | Ptype_abstract ->
-          Option.fold ~none:Typrepr.empty ~some:(derive_ctype s params)
-            ptype_manifest
+          Option.fold
+            ~none:(Typrepr.empty td.ptype_name.txt)
+            ~some:(derive_ctype s params) ptype_manifest
       | Ptype_variant constructors ->
           let constr_f c =
             match c.pcd_args with
@@ -153,8 +154,8 @@ let rec derive_decl (s : Module_state.t) params
       | Ptype_record labs ->
           let lab_f l = (l.pld_name.txt, derive_ctype s params l.pld_type) in
           Typrepr.Record.make (List.map lab_f labs)
-      | Ptype_open -> Typrepr.empty )
-  with Invalid_argument _ | Exit -> Typrepr.empty
+      | Ptype_open -> Typrepr.empty td.ptype_name.txt )
+  with Invalid_argument _ | Exit -> Typrepr.empty td.ptype_name.txt
 
 (* derivation function for core types *)
 and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
@@ -181,7 +182,7 @@ and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
         let input = derive_ctype state params input in
         let output = derive_ctype state params output in
         Typrepr.Arrow.make input output
-    | _ -> Typrepr.empty )
+    | _ -> Typrepr.empty (Format.asprintf "%a" print_coretype ct) )
 
 let derive state (recflag, typs) =
   Log.type_decl (recflag, typs) ;

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -155,18 +155,15 @@ let derive state (recflag, typs) =
   Log.type_decl (recflag, typs) ;
   (* we pre-fill the environment with the type being processed (for recursive
      types)*)
-  let state =
-    match recflag with
-    | Recursive ->
-        List.fold_left
-          (fun acc td ->
-            Module_state.update acc
-              (lparse td.ptype_name.txt)
-              (Typrepr.Rec.make td.ptype_name.txt) )
-          state typs
-    | Nonrecursive -> state
-  in
   let rec_, nonrec_ = rec_nonrec recflag typs in
+  let state =
+    List.fold_left
+      (fun acc td ->
+        Module_state.update acc
+          (lparse td.ptype_name.txt)
+          (Typrepr.Rec.make td.ptype_name.txt) )
+      state rec_
+  in
   let is_rec td =
     List.exists (fun td' -> td'.ptype_name.txt = td.ptype_name.txt) rec_
   in
@@ -214,7 +211,11 @@ let derive state (recflag, typs) =
         | _ -> (mono, td :: poly) )
       ([], []) rec_
   in
-  let mono_typs = Typrepr.Rec.finish (List.rev mono_typs) in
+  let mono_typs =
+    match mono_typs with
+    | [] -> []
+    | _ -> Typrepr.Rec.finish (List.rev mono_typs)
+  in
   let state =
     List.fold_left
       (fun state td ->

--- a/src/satisfying.ml
+++ b/src/satisfying.ml
@@ -135,7 +135,7 @@ let rec derive_decl (s : Module_state.t) params
     match ptype_kind with
     | Ptype_abstract ->
         Option.fold
-          ~none:(Typrepr.empty td.ptype_name.txt)
+          ~none:(Typrepr.empty !current_loc td.ptype_name.txt)
           ~some:(derive_ctype s params) ptype_manifest
     | Ptype_variant constructors ->
         let constr_f c =
@@ -153,7 +153,7 @@ let rec derive_decl (s : Module_state.t) params
     | Ptype_record labs ->
         let lab_f l = (l.pld_name.txt, derive_ctype s params l.pld_type) in
         Typrepr.Record.make (List.map lab_f labs)
-    | Ptype_open -> Typrepr.empty td.ptype_name.txt )
+    | Ptype_open -> Typrepr.empty !current_loc td.ptype_name.txt )
 
 (* derivation function for core types *)
 and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
@@ -167,7 +167,7 @@ and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
     | Ptyp_var var -> List.assoc var params
     | Ptyp_constr ({txt; _}, []) ->
         Option.fold ~some:Fun.id
-          ~none:(Typrepr.empty (lid_to_string txt))
+          ~none:(Typrepr.empty !current_loc (lid_to_string txt))
           (Module_state.get txt state)
     | Ptyp_constr ({txt; _}, l) ->
         let p = Module_state.get_param txt state |> Option.get in
@@ -183,7 +183,8 @@ and derive_ctype (state : Module_state.t) params ct : Typrepr.t =
         let input = derive_ctype state params input in
         let output = derive_ctype state params output in
         Typrepr.Arrow.make input output
-    | _ -> Typrepr.empty (Format.asprintf "%a" print_coretype ct) )
+    | _ ->
+        Typrepr.empty !current_loc (Format.asprintf "%a" print_coretype ct) )
 
 let derive state (recflag, typs) =
   Log.type_decl (recflag, typs) ;

--- a/src/solver/cover.ml
+++ b/src/solver/cover.ml
@@ -92,10 +92,11 @@ module Make (D : Signatures.Abs) = struct
             | Unsat -> cover'
             | Sat -> add_inner cover' biggest
             | Filtered ((abs', _), true) -> add_inner cover' abs'
-            | Filtered ((abs', c), false) ->
-                List.fold_left
-                  (fun acc elm -> add_outer acc elm c)
-                  cover' (D.split abs')
+            | Filtered ((abs', c), false) -> (
+              try
+                let l = D.split abs' in
+                List.fold_left (fun acc elm -> add_outer acc elm c) cover' l
+              with _ -> add_outer cover' abs' c )
           in
           aux new_cover
     in

--- a/src/state.ml
+++ b/src/state.ml
@@ -59,7 +59,9 @@ let register_print (s : t) lid p =
     types=
       Env.update lid
         (function
-          | None -> Some Typrepr.(add_printer (empty (lid_to_string lid)) p)
+          | None ->
+              let typ = Typrepr.empty !current_loc (lid_to_string lid) in
+              Some (Typrepr.add_printer typ p)
           | Some info -> Some Typrepr.(add_printer info p) )
         s.types }
 
@@ -69,7 +71,8 @@ let register_gen (s : t) lid g =
       Env.update lid
         (function
           | None ->
-              Some Typrepr.(add_generator (empty (lid_to_string lid)) g)
+              let typ = Typrepr.empty !current_loc (lid_to_string lid) in
+              Some (Typrepr.add_generator typ g)
           | Some info -> Some Typrepr.(add_generator info g) )
         s.types }
 
@@ -79,8 +82,8 @@ let register_prop (s : t) lid spec =
       Env.update lid
         (function
           | None ->
-              Some
-                Typrepr.(add_specification (empty (lid_to_string lid)) spec)
+              let typ = Typrepr.empty !current_loc (lid_to_string lid) in
+              Some (Typrepr.add_specification typ spec)
           | Some info -> Some Typrepr.(add_specification info spec) )
         s.types }
 

--- a/src/state.ml
+++ b/src/state.ml
@@ -59,7 +59,7 @@ let register_print (s : t) lid p =
     types=
       Env.update lid
         (function
-          | None -> Some Typrepr.(add_printer empty p)
+          | None -> Some Typrepr.(add_printer (empty (lid_to_string lid)) p)
           | Some info -> Some Typrepr.(add_printer info p) )
         s.types }
 
@@ -68,7 +68,8 @@ let register_gen (s : t) lid g =
     types=
       Env.update lid
         (function
-          | None -> Some Typrepr.(add_generator empty g)
+          | None ->
+              Some Typrepr.(add_generator (empty (lid_to_string lid)) g)
           | Some info -> Some Typrepr.(add_generator info g) )
         s.types }
 
@@ -77,7 +78,9 @@ let register_prop (s : t) lid spec =
     types=
       Env.update lid
         (function
-          | None -> Some Typrepr.(add_specification empty spec)
+          | None ->
+              Some
+                Typrepr.(add_specification (empty (lid_to_string lid)) spec)
           | Some info -> Some Typrepr.(add_specification info spec) )
         s.types }
 

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -43,9 +43,10 @@ let print fmt {gen; spec; card; print; boltz; of_arbogen; collector} =
 
 let default_printer = lambda_s "_" (string_ "<...>")
 
-let empty =
-  { boltz= Error "No Boltzmann spec for the empty type"
-  ; of_arbogen= Error "No of_arbogen function for the empty type"
+let empty (name : string) =
+  let error args = Format.ksprintf Result.error args in
+  { boltz= error "No Boltzmann spec for type \"%s\"" name
+  ; of_arbogen= error "No of_arbogen function for type \"%s\"" name
   ; gen= None
   ; spec= None
   ; card= Unknown

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -4,23 +4,29 @@ open Parsetree
 open Helper
 open Location
 
-(** representation of an OCaml type *)
+(** {1 Internal representation of an OCaml type} *)
 
 type t =
   { boltz: (Boltz.t, string) Result.t
+        (** Combinatorial specification of the type *)
   ; of_arbogen: (expression, string) Result.t
+        (** AST of a function that converts an arbogen tree to the current
+            type *)
+  ; collector: expression option
+        (** AST of a function collecting values subject to a global
+            constraint in an inhabitant of the type. *)
   ; gen: expression option
-  ; spec: expression option
-  ; card: Card.t
-  ; print: expression
-  ; collector: expression option }
+        (** AST of a random sampler for the current type *)
+  ; spec: expression option  (** AST of a predicate over the current type *)
+  ; card: Card.t  (** Cardinality of the type *)
+  ; print: expression  (** AST of a pretty-printer for the type *) }
 
-(** {2 Printing}*)
-
-let print_expr fmt e =
-  Format.fprintf fmt "\n```ocaml@.@[%a@]\n```" print_expression e
+(** {2 Printing} *)
 
 let print fmt {gen; spec; card; print; boltz; of_arbogen; collector} =
+  let print_expr fmt =
+    Format.fprintf fmt "\n```ocaml@.@[%a@]\n```" print_expression
+  in
   let print_opt f fmt = function
     | None -> Format.fprintf fmt " none"
     | Some e -> f fmt e
@@ -39,9 +45,7 @@ let print fmt {gen; spec; card; print; boltz; of_arbogen; collector} =
   Format.fprintf fmt "- Generator: %a\n" (print_opt print_expr) gen ;
   Format.fprintf fmt "- Collector: %a\n" (print_opt print_expr) collector
 
-(** {2 Constructors}*)
-
-let default_printer = lambda_s "_" (string_ "<...>")
+(** {2 Constructors} *)
 
 let empty (name : string) =
   let error args = Format.ksprintf Result.error args in
@@ -50,7 +54,7 @@ let empty (name : string) =
   ; gen= None
   ; spec= None
   ; card= Unknown
-  ; print= default_printer
+  ; print= lambda_s "_" (string_ "<...>")
   ; collector= None }
 
 let add_printer info p = {info with print= p}

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -607,7 +607,7 @@ module Sum = struct
               (constr [[%pat? x1]])
               [%expr
                 let x1', queue' = [%e of_arbg] x1 queue rs in
-                [%e construct name (Some [%expr x1'])]] )
+                ([%e construct name (Some [%expr x1'])], queue')] )
           x.of_arbogen
     | p ->
         let pat, exp = pat_exp (List.map fst p) id in

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -810,7 +810,7 @@ module Constrained = struct
     in
     let default =
       { typ with
-        gen= Option.map (rejection e) typ.gen
+        gen= Option.map (rejection spec) typ.gen
       ; spec= Some spec
       ; card= Unknown }
     in

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -208,7 +208,8 @@ module Rec = struct
         let loc = !current_loc in
         [%expr
           fun rs ->
-            let sicstus_something _ = assert false in
+            (* let sicstus_something _ = assert false in *)
+            let sicstus_something n = List.init n Fun.id in
             let wg = [%e wg] in
             let tree = Arbg.generate wg [%e string_ name] rs in
             let nb_collect = Arbg.count_collect tree in

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -211,7 +211,7 @@ module Rec = struct
         fun rs ->
           let sicstus_something _ = assert false in
           let wg = [%e AGPrint.weighted_grammar wg] in
-          let tree = Arbg.free_gen wg [%e string_ name] rs in
+          let tree = Arbg.generate wg [%e string_ name] rs in
           let nb_collect = Arbg.count_collect tree in
           let queue = sicstus_something nb_collect in
           fst ([%e of_arbogen] tree queue rs)]
@@ -288,7 +288,7 @@ module Infinite = struct
         let sicstus_something _ = assert false in
         let of_arbogen _ _ = assert false in
         let wg = [%e AGPrint.weighted_grammar wg] in
-        let tree = Arbg.free_gen wg rs in
+        let tree = Arbg.generate wg [%e string_ name] rs in
         let nb_collect = Arbg.count_collect tree in
         let vals = sicstus_something nb_collect in
         fst (of_arbogen vals tree)]
@@ -518,8 +518,8 @@ module Sum = struct
                *)
                  if collect then Arbogen.Grammar.Ref "@collect"
                  else Option.get t.boltz_spec )
-          |> List.cons (Arbogen.Grammar.Z 1)
           |> Arbogen.Grammar.product
+          |> fun e -> Arbogen.Grammar.(product [Z 1; e])
     in
     try
       match List.map variant_spec variants with
@@ -532,7 +532,7 @@ module Sum = struct
   let constr_arbg name args =
     let id = id_gen_gen () in
     let constr pats =
-      Pat.construct_s "Arbogen.Tree.Node"
+      Pat.construct_s "Arbogen.Tree.Label"
         (Some (Pat.pair (Pat.string name) (Pat.list pats)))
     in
     match args with

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -200,29 +200,21 @@ module Rec = struct
       |> Arbogen.Frontend.ParseTree.completion
       |> Arbogen.Frontend.ParseTree.to_grammar
     in
-    try
-      let wg =
-        Arbogen.Boltzmann.(
-          WeightedGrammar.of_grammar
-            (Oracle.Naive.make_expectation 30 grammar)
-            grammar)
-      in
-      fun name of_arbogen ->
-        [%expr
-          fun rs ->
-            let sicstus_something _ = assert false in
-            let wg = [%e AGPrint.weighted_grammar wg] in
-            let tree = Arbg.free_gen wg [%e string_ name] rs in
-            let nb_collect = Arbg.count_collect tree in
-            let queue = sicstus_something nb_collect in
-            fst ([%e of_arbogen] tree queue rs)]
-    with Invalid_argument _ ->
-      fun _ _ ->
-        let loc = !current_loc in
-        [%expr
-          fun rs ->
-            ignore rs ;
-            assert false]
+    let wg =
+      Arbogen.Boltzmann.(
+        WeightedGrammar.of_grammar
+          (Oracle.Naive.make_expectation 30 grammar)
+          grammar)
+    in
+    fun name of_arbogen ->
+      [%expr
+        fun rs ->
+          let sicstus_something _ = assert false in
+          let wg = [%e AGPrint.weighted_grammar wg] in
+          let tree = Arbg.free_gen wg [%e string_ name] rs in
+          let nb_collect = Arbg.count_collect tree in
+          let queue = sicstus_something nb_collect in
+          fst ([%e of_arbogen] tree queue rs)]
 
   let rec_def header get_field typs =
     List.map

--- a/src/typrepr.ml
+++ b/src/typrepr.ml
@@ -47,14 +47,14 @@ let print fmt {gen; spec; card; print; boltz; of_arbogen; collector} =
 
 (** {2 Constructors} *)
 
-let empty (name : string) =
+let empty loc (name : string) =
   let error args = Format.ksprintf Result.error args in
   { boltz= error "No Boltzmann spec for type \"%s\"" name
   ; of_arbogen= error "No of_arbogen function for type \"%s\"" name
   ; gen= None
   ; spec= None
   ; card= Unknown
-  ; print= lambda_s "_" (string_ "<...>")
+  ; print= [%expr fun _ -> "<...>"]
   ; collector= None }
 
 let add_printer info p = {info with print= p}


### PR DESCRIPTION
Integration of `of_arbogen` functions in blotzmann generation, addition of Arbogen-related primitives into the runtime to reduce the size of generated code